### PR TITLE
Respect user font smoothing settings

### DIFF
--- a/Aerochat/App.xaml
+++ b/Aerochat/App.xaml
@@ -11,7 +11,14 @@
             </ResourceDictionary.MergedDictionaries>
             <Style x:Key="Window" TargetType="{x:Type Window}" BasedOn="{StaticResource {x:Type Window}}">
                 <Setter Property="TextOptions.TextFormattingMode" Value="Display" />
-                <Setter Property="TextOptions.TextRenderingMode" Value="ClearType" />
+                
+                <!-- Set up text rendering mode respecting the user's ClearType preferences -->
+                <Setter Property="TextOptions.TextRenderingMode">
+                    <Setter.Value>
+                        <Binding Source="{x:Static local:FontAppearanceManager.Instance}" Path="TextRenderingMode"></Binding>
+                    </Setter.Value>
+                </Setter>
+                
                 <Setter Property="UseLayoutRounding" Value="True" />
             </Style>
             <Style TargetType="Image">

--- a/Aerochat/Controls/BasicTitlebar.cs
+++ b/Aerochat/Controls/BasicTitlebar.cs
@@ -248,7 +248,7 @@ namespace Aerochat.Controls
         private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
         {
             switch (msg) {
-                case 0x31E:
+                case 0x31E: // WM_DWMCOMPOSITIONCHANGED
                     DwmIsCompositionEnabled(out bool enabled);
                     if (enabled != IsDwmEnabled)
                     {
@@ -257,7 +257,7 @@ namespace Aerochat.Controls
                     }
                     OnDwmChanged();
                     break;
-                case 0x000C:
+                case 0x000C: // WM_SETTEXT
                     string? newText = Marshal.PtrToStringAuto(wParam);
                     if (newText != null)
                     {

--- a/Aerochat/FontAppearanceManager.cs
+++ b/Aerochat/FontAppearanceManager.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Media;
+using static Vanara.PInvoke.User32;
+
+namespace Aerochat
+{
+    /// <summary>
+    /// Determines if an application should use ClearType or aliased fonts.
+    /// </summary>
+    internal class FontAppearanceManager
+    {
+        private static FontAppearanceManager _instance;
+        private TextRenderingMode _textRenderingMode = TextRenderingMode.Auto;
+
+        public static FontAppearanceManager Instance
+        {
+            get => _instance;
+            private set => _instance = value;
+        }
+
+        public TextRenderingMode TextRenderingMode
+        {
+            get => _textRenderingMode;
+            private set { }
+        }
+
+        static FontAppearanceManager()
+        {
+            _instance = new FontAppearanceManager();
+        }
+
+        public FontAppearanceManager()
+        {
+            Refresh();
+        }
+
+        /// <summary>
+        /// Refresh the font smoothing settings.
+        /// </summary>
+        /// <remarks>
+        /// The font rendering settings can change during a window's lifetime. This should be able to be
+        /// detected via looking at WM_SETTINGCHANGE in the window procedure.
+        /// 
+        /// Aerochat does have a custom window procedure right now, but it's in a separate module. Some
+        /// tiny work will need to be done to generalise it for detecting the settings change. For now,
+        /// detection only works at application startup and font setting changes made in the middle of
+        /// the application running will be ignored.
+        /// </remarks>
+        public void Refresh()
+        {
+            bool bFontSmoothingEnabled = false;
+            bool spiResult = SystemParametersInfo(SPI_GETFONTSMOOTHING, 0, ref bFontSmoothingEnabled, false);
+
+            if (!spiResult)
+            {
+                // If we failed the SystemParametersInfo call for whatever reason, then we'll just let
+                // WPF handle it. This shouldn't happen, but it may happen due to marshalling failures
+                // (maybe a concern on Linux via Wine?).
+                _textRenderingMode = TextRenderingMode.Auto;
+                return;
+            }
+
+            // Check to see if the user has font smoothing enabled at all:
+
+            if (!bFontSmoothingEnabled)
+            {
+                // If this is the case, then the user has completely disabled font smoothing. No fonts
+                // should be smoothed under any circumstances.
+                _textRenderingMode = TextRenderingMode.Aliased;
+                return;
+            }
+
+            // Otherwise, check the user's font smoothing type:
+
+            int uiType = FE_FONTSMOOTHINGSTANDARD;
+            spiResult = SystemParametersInfo(SPI_GETFONTSMOOTHINGTYPE, 0, ref uiType, false);
+
+            if (!spiResult)
+            {
+                // If we failed the SystemParametersInfo call for whatever reason, then we'll just let
+                // WPF handle it. This shouldn't happen, but it can happen due to marshalling failures
+                // (maybe a concern on Linux via Wine?).
+                _textRenderingMode = TextRenderingMode.Auto;
+                return;
+            }
+
+            if (uiType == FE_FONTSMOOTHINGCLEARTYPE)
+            {
+                // The user has ClearType enabled.
+                _textRenderingMode = TextRenderingMode.ClearType;
+            }
+            else // assume FE_FONTSMOOTHINGSTANDARD
+            {
+                /*
+                 * This will probably fall back to aliased, but I didn't just want to assume that in
+                 * case of small differences.
+                 * 
+                 * Note that ClearType being disabled is not the same as font smoothing being disabled
+                 * system wide. In the case of ClearType being disabled, pixelated fonts are preferred,
+                 * but smooth fonts will be used in large scales and when they are the only option.
+                 * 
+                 * This appears to have the correct behaviour in this case: large fonts are still smoothed
+                 * and small fonts are pixelated when pixel glyphs are available.
+                 */
+                _textRenderingMode = TextRenderingMode.Auto;
+            }
+        }
+
+        private const int SPI_GETFONTSMOOTHING = 0x004A;
+        private const int SPI_GETFONTSMOOTHINGTYPE = 0x200A;
+        private const int FE_FONTSMOOTHINGSTANDARD = 1;
+        private const int FE_FONTSMOOTHINGCLEARTYPE = 2;
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool SystemParametersInfo(int uiAction, uint uiParam, ref bool pvParam, bool fWinIni);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool SystemParametersInfo(int uiAction, uint uiParam, ref int pvParam, bool fWinIni);
+    }
+}


### PR DESCRIPTION
WPF by default doesn't respect the user's font smoothing settings, and instead uses smooth fonts in all cases. Oddly enough, it's pretty much natively capable of handling fonts like other native applications do. With a tiny wrapper, you can replicate just about how GDI DrawText will produce text according to the user's settings.

Windows Live Messenger was built with DirectUI, which used GDI or GDI+ for font rendering. This commit makes font rendering slightly more accurate to the actual WLM clients.

(+ I added a couple documentation comments in a secondary commit)