### PR TITLE
Added a truncated message w/ author for messages that are a reply

### DIFF
--- a/Aerochat/ViewModels/Message.cs
+++ b/Aerochat/ViewModels/Message.cs
@@ -22,6 +22,8 @@ namespace Aerochat.ViewModels
         private bool _special = false;
         private bool _hiddenInfo = false;
         private string _type;
+        private bool _isReply = false;
+        private MessageViewModel? _replyMessage;
 
         public UserViewModel? Author
         {
@@ -73,10 +75,22 @@ namespace Aerochat.ViewModels
             set => SetProperty(ref _type, value);
         }
 
+        public bool IsReply
+        {
+            get => _isReply;
+            set => SetProperty(ref _isReply, value);
+        }
+
+        public MessageViewModel? ReplyMessage
+        {
+            get => _replyMessage;
+            set => SetProperty(ref _replyMessage, value);
+        }
+
         public ObservableCollection<AttachmentViewModel> Attachments { get; } = new();
         public ObservableCollection<EmbedViewModel> Embeds { get; } = new();
 
-        public static MessageViewModel FromMessage(DiscordMessage message, DiscordMember? member = null)
+        public static MessageViewModel FromMessage(DiscordMessage message, DiscordMember? member = null, bool isReply = false)
         {
             var user = member == null ? UserViewModel.FromUser(message.Author) : UserViewModel.FromMember(member);
             var vm = new MessageViewModel
@@ -85,7 +99,8 @@ namespace Aerochat.ViewModels
                 Id = message.Id,
                 Timestamp = message.Timestamp.DateTime,
                 RawMessage = message.Content,
-                Type = message.MessageType?.ToString() ?? "Unknown"
+                Type = message.MessageType?.ToString() ?? "Unknown",
+                IsReply = message.MessageType == MessageType.Reply && !isReply
             };
             foreach (var embed in message.Embeds)
             {
@@ -140,6 +155,11 @@ namespace Aerochat.ViewModels
             foreach (var attachment in message.Attachments)
             {
                 vm.Attachments.Add(AttachmentViewModel.FromAttachment(attachment));
+            }
+
+            if (vm.IsReply)
+            {
+                vm.ReplyMessage = FromMessage(message.ReferencedMessage, null, true);
             }
 
             return vm;

--- a/Aerochat/Windows/Chat.xaml
+++ b/Aerochat/Windows/Chat.xaml
@@ -854,6 +854,28 @@
                                             </StackPanel>
                                             <StackPanel Grid.Row="2" Margin="8,-6,0,0">
                                                 <Grid>
+                                                    <Grid.Style>
+                                                        <Style TargetType="Grid">
+                                                            <Setter Property="Visibility" Value="Collapsed" />
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsReply}" Value="True">
+                                                                    <Setter Property="Visibility" Value="Visible" />
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </Grid.Style>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto" />
+                                                        <ColumnDefinition Width="*" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <Rectangle Grid.Column="0" Height="1" Width="6" Fill="#bbbbbb" VerticalAlignment="Top" Margin="0,10,8,0" />
+                                                    <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="0,4" MouseLeftButtonDown="JumpToReply" Cursor="Hand">
+                                                        <TextBlock FontSize="9" Grid.Row="0" HorizontalAlignment="Stretch" TextWrapping="NoWrap" Text="{Binding ReplyMessage.Author.Name}" />
+                                                        <TextBlock FontSize="9" Grid.Row="1" Text=" said: " />
+                                                        <TextBlock FontSize="9" Grid.Row="2" Text="{Binding ReplyMessage.Message}" TextTrimming="WordEllipsis" MaxWidth="250" />
+                                                    </StackPanel>
+                                                </Grid>
+                                                <Grid>
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="Auto" />
                                                         <ColumnDefinition Width="*" />

--- a/Aerochat/Windows/Chat.xaml.cs
+++ b/Aerochat/Windows/Chat.xaml.cs
@@ -906,5 +906,26 @@ namespace Aerochat.Windows
             await SendMessage("[nudge]");
             ExecuteNudgePrettyPlease(Left, Top).ConfigureAwait(false);
         }
+
+        private void JumpToReply(object sender, MouseButtonEventArgs e)
+        {
+            var messageVm = (sender as StackPanel)?.DataContext as MessageViewModel;
+            if (messageVm is null || !messageVm.IsReply || messageVm.ReplyMessage is null) return;
+
+            var replyId = messageVm.ReplyMessage.Id;
+            for (var i = 0; i < MessagesListItemsControl.Items.Count; i++)
+            {
+                var item = MessagesListItemsControl.Items[i] as MessageViewModel;
+                if (item is null) return;
+
+                if (item.Id != replyId) continue;
+
+                var container = MessagesListItemsControl.ItemContainerGenerator.ContainerFromItem(item) as FrameworkElement;
+                if (container is null) return;
+
+                container.BringIntoView();
+                return;
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds a new Grid to the StackPanel that the TextBlock that Message is bound to belongs in.

Adds an event called `JumpToReply` which essentially finds the ModelView belonging to the replied-to message within `MessagesListItemsControl` and scrolls directly to it by using `FrameworkElement.BringIntoView()`

Adds two properties to `MessageViewModel` in `Message.cs` named `IsReply` and `ReplyMessage`. `IsReply` is used to conditionally set `ReplyMessage` based on whether the message actually is a reply, but also whether *that* message should be replied to as well. The signature for `MessageViewModel.FromMessage` has been changed to append the variable `isReply` to the end that is used to avoid a recursion-based error.