### PR TITLE
Bugfix: JumpToReply not working because of the control changing from StackPanel to Grid

### DIFF
--- a/Aerochat/Windows/Chat.xaml.cs
+++ b/Aerochat/Windows/Chat.xaml.cs
@@ -933,7 +933,7 @@ namespace Aerochat.Windows
 
         private void JumpToReply(object sender, MouseButtonEventArgs e)
         {
-            var messageVm = (sender as StackPanel)?.DataContext as MessageViewModel;
+            var messageVm = (sender as Panel)?.DataContext as MessageViewModel;
             if (messageVm is null || !messageVm.IsReply || messageVm.ReplyMessage is null) return;
 
             var replyId = messageVm.ReplyMessage.Id;


### PR DESCRIPTION
Modified `JumpToReply` so that `object sender` is casted to a more generic type `Panel` since the change from the original `StackPanel` to `Grid` broke the functionality. This should help the functionality survive if the control changes to another similarly typed control.