### PR TITLE
fix: Messages sent in DMs and Group DMs don't get updated when the DM window is open

### DIFF
--- a/Aerochat/Windows/Chat.xaml.cs
+++ b/Aerochat/Windows/Chat.xaml.cs
@@ -413,9 +413,7 @@ namespace Aerochat.Windows
                     user = Discord.Client.GetUserAsync(args.Author.Id).Result;
                 };
 
-                var member = args.Guild.Members.FirstOrDefault(x => x.Key == args.Author.Id).Value;
-
-                MessageViewModel message = MessageViewModel.FromMessage(args.Message, member ?? (DiscordMember)args.Author);
+                MessageViewModel message = MessageViewModel.FromMessage(args.Message);
 
                 foreach (var attachment in args.Message.Attachments)
                 {

--- a/Aerochat/Windows/Chat.xaml.cs
+++ b/Aerochat/Windows/Chat.xaml.cs
@@ -413,7 +413,9 @@ namespace Aerochat.Windows
                     user = Discord.Client.GetUserAsync(args.Author.Id).Result;
                 };
 
-                MessageViewModel message = MessageViewModel.FromMessage(args.Message);
+                var member = args.Guild?.Members.FirstOrDefault(x => x.Key == args.Author.Id).Value;
+
+                MessageViewModel message = MessageViewModel.FromMessage(args.Message, member);
 
                 foreach (var attachment in args.Message.Attachments)
                 {


### PR DESCRIPTION
Fixes [this issue](https://canary.discord.com/channels/1196169343864684605/1286370827855593523) posted in the Discord server.

> *Basically whenever a new message in a group DM or a regular DM is sent, the chat window will not update with the new messages and requires the user to close and re-open the DM window to see new messages.* 
>
> *Happens whenever sending messages as well. It will always show as light grey even though it was sent in the background.*

Seems to have occurred because the Guild check happened while in a DM, which returned null. `FromMessage` accepts null member so we can return a null member if guild is null. (null overload!!)