### PR TITLE
Feature: Image Previewer

### DIFF
--- a/Aerochat/ViewModels/ImagePreviewerViewModel.cs
+++ b/Aerochat/ViewModels/ImagePreviewerViewModel.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Media.Imaging;
+
+namespace Aerochat.ViewModels
+{
+    public sealed class ImagePreviewerViewModel: ViewModelBase
+    {
+        private string _filename;
+        private string _sourceUri;
+
+        public string FileName
+        {
+            get => _filename;
+            set => SetProperty(ref _filename, value);
+        }
+
+        public string SourceUri
+        {
+            get => _sourceUri;
+            set => SetProperty(ref _sourceUri, value);
+        }
+    }
+}

--- a/Aerochat/Windows/Chat.xaml
+++ b/Aerochat/Windows/Chat.xaml
@@ -1039,7 +1039,7 @@
                                                     <ItemsControl.ItemTemplate>
                                                         <DataTemplate>
                                                             <StackPanel>
-                                                                <Image Margin="0,16,0,6" HorizontalAlignment="Left" MaxWidth="250" MaxHeight="{Binding Height}" Source="{Binding Url}" />
+                                                                <Image Margin="0,16,0,6" HorizontalAlignment="Left" MaxWidth="250" MaxHeight="{Binding Height}" Source="{Binding Url}" MouseLeftButtonDown="OpenImage" />
                                                                 <TextBlock Margin="0,2">
                                                                     <TextBlock.Text>
                                                                         <MultiBinding StringFormat="{}{0} ({1})">

--- a/Aerochat/Windows/Chat.xaml.cs
+++ b/Aerochat/Windows/Chat.xaml.cs
@@ -980,5 +980,27 @@ namespace Aerochat.Windows
                     }
             }
         }
+
+        private void OpenImage(object sender, MouseButtonEventArgs e)
+        {
+            var image = (sender as Image);
+            if (image is null) return;
+
+            var attachmentVm = image.DataContext as AttachmentViewModel;
+            if (attachmentVm is null) return;
+
+            var imagePreviewer = new ImagePreviewer(image.Source.ToString(), attachmentVm.Name)
+            {
+                Owner = this,
+                Width = attachmentVm.Width,
+                Height = attachmentVm.Height,
+                MaxWidth = 800,
+                MaxHeight = attachmentVm.Height
+            };
+
+            imagePreviewer.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+
+            imagePreviewer.ShowDialog();
+        }
     }
 }

--- a/Aerochat/Windows/ImagePreviewer.xaml
+++ b/Aerochat/Windows/ImagePreviewer.xaml
@@ -1,0 +1,32 @@
+﻿<Window x:Class="Aerochat.Windows.ImagePreviewer"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:viewmodels="clr-namespace:Aerochat.ViewModels" d:DataContext="{d:DesignInstance Type=viewmodels:ImagePreviewerViewModel}"
+        xmlns:local="clr-namespace:Aerochat.Windows"
+        mc:Ignorable="d"
+        Title="{Binding FileName}"
+        WindowStyle="None"
+        KeyDown="OnKeyDown"
+        Deactivated="OnDeactivated">
+    <Grid>
+        <Grid.Background>
+            <ImageBrush ImageSource="{Binding SourceUri}" Stretch="UniformToFill" />
+        </Grid.Background>
+            <TextBlock HorizontalAlignment="Left" VerticalAlignment="Bottom" FontSize="13" FontWeight="DemiBold" Text="Open In Browser" Padding="10" Cursor="Hand" MouseLeftButtonDown="OpenImage">
+            <TextBlock.Style>
+                <Style TargetType="TextBlock">
+                    <Setter Property="Foreground" Value="#999999" />
+                    <Setter Property="TextDecorations" Value="None" />
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Foreground" Value="White" />
+                            <Setter Property="TextDecorations" Value="Underline" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+        </TextBlock>
+    </Grid>
+</Window>

--- a/Aerochat/Windows/ImagePreviewer.xaml.cs
+++ b/Aerochat/Windows/ImagePreviewer.xaml.cs
@@ -1,0 +1,56 @@
+﻿using Aerochat.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace Aerochat.Windows
+{
+    /// <summary>
+    /// Interaction logic for ImagePreviewer.xaml
+    /// </summary>
+    public partial class ImagePreviewer : Window
+    {
+        public ImagePreviewerViewModel ViewModel { get; private set; }
+
+        public ImagePreviewer(string source, string fileName)
+        {
+            ViewModel = new ImagePreviewerViewModel
+            {
+                FileName = fileName,
+                SourceUri = source,
+            };
+
+            DataContext = ViewModel;
+            InitializeComponent();
+        }
+
+        private void OpenImage(object sender, MouseButtonEventArgs e)
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = ViewModel.SourceUri,
+                UseShellExecute = true
+            });
+        }
+
+        private void OnKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key != Key.Escape) return;
+
+            Close();
+        }
+
+        private void OnDeactivated(object sender, EventArgs e) => Close();
+    }
+}


### PR DESCRIPTION
When a user clicks on an image within the chat window that image source is passed to a new instance of `ImagePreviewer` that renders the image on a window with a width/height based on the image attributes. The user is then able to open that image in their default browser or close the window through two methods: `Esc` and clicking anywhere off that window.