### PR TITLE
fix: Disable tabbing on custom window frame

### DIFF
--- a/Aerochat/Controls/NoDwmTitlebar.xaml
+++ b/Aerochat/Controls/NoDwmTitlebar.xaml
@@ -5,7 +5,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Aerochat.Controls" xmlns:viewmodels="clr-namespace:Aerochat.ViewModels" d:DataContext="{d:DesignInstance Type=viewmodels:BasicTitlebarViewModel}"
              mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
+             d:DesignHeight="450" d:DesignWidth="800"
+             KeyboardNavigation.TabNavigation="None">
     <Border Background="{Binding Color}" CornerRadius="8,8,0,0">
         <Grid>
             <Grid>


### PR DESCRIPTION
Window frame elements should not be tabbable, but the custom XAML window frame did allow the elements to be tabbed to.