### PR TITLE
feat: Proper system menu handling with custom window frames

### DIFF
--- a/Aerochat/Controls/NoDwmTitlebar.xaml
+++ b/Aerochat/Controls/NoDwmTitlebar.xaml
@@ -16,8 +16,8 @@
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
-                <Button WindowChrome.IsHitTestVisibleInChrome="True" MouseDoubleClick="Button_MouseDoubleClick" Grid.Column="1" Style="{StaticResource TransparentStyle}">
-                    <Image Source="{Binding Icon}" />
+                <Button x:Name="SystemMenuButton" Grid.Column="1" Style="{StaticResource TransparentStyle}">
+                    <Image x:Name="SystemMenuImage" Source="{Binding Icon}" />
                 </Button>
                 <TextBlock Grid.Column="2" Foreground="{Binding TextColor}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5,0,0,0" Text="{Binding Title}">
                     <TextBlock.Style>

--- a/Aerochat/Controls/NoDwmTitlebar.xaml.cs
+++ b/Aerochat/Controls/NoDwmTitlebar.xaml.cs
@@ -48,11 +48,5 @@ namespace Aerochat.Controls
             if (Window.GetWindow(this) is not Window window) return;
             window.Close();
         }
-
-        private void Button_MouseDoubleClick(object sender, MouseButtonEventArgs e)
-        {
-            if (Window.GetWindow(this) is not Window window) return;
-            window.Close();
-        }
     }
 }


### PR DESCRIPTION
Previously, the system menu was not opened if you clicked the application icon in the titlebar, but there was support for the double-click-to-close behaviour of the button.

This commit modifies the window procedure hook to handle this element properly. Now the native system menu is opened when you click the item.

![image](https://github.com/user-attachments/assets/b0d4050f-f26e-48ba-b8e2-7b2351eb48c1)

Additionally, some of the BasicTitlebar.cs code was refactored.