### PR TITLE
refactor: Use Vanara.PInvoke for all* interop

### DIFF
--- a/Aerochat/Controls/BasicTitlebar.cs
+++ b/Aerochat/Controls/BasicTitlebar.cs
@@ -12,7 +12,9 @@ using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shell;
+using Vanara.PInvoke;
 using static Vanara.PInvoke.User32;
+using static Vanara.PInvoke.User32.WindowMessage;
 using Color = System.Windows.Media.Color;
 
 namespace Aerochat.Controls
@@ -26,7 +28,7 @@ namespace Aerochat.Controls
         Border SecondBorder;
         Grid Container;
         public bool IsDwmEnabled { get; private set; }
-        public BaseTitlebar() 
+        public BaseTitlebar()
         {
             DwmIsCompositionEnabled(out bool isEnabled);
             IsDwmEnabled = isEnabled;
@@ -104,7 +106,7 @@ namespace Aerochat.Controls
                 ContentTemplateSelector = ContentTemplateSelector,
                 ContentStringFormat = ContentStringFormat
             };
-            
+
             var titlebar = new NoDwmTitlebar();
             titlebar.ViewModel.TextColor = new SolidColorBrush(BlackText);
             titlebar.ViewModel.Color = new SolidColorBrush(Color);
@@ -124,7 +126,7 @@ namespace Aerochat.Controls
 
             Border whiteBorder = new();
             // set to white, opacity 32, thickness 1
-            whiteBorder.BorderBrush = new SolidColorBrush(Color.FromArgb(127, 255,255,255));
+            whiteBorder.BorderBrush = new SolidColorBrush(Color.FromArgb(127, 255, 255, 255));
             whiteBorder.BorderThickness = new Thickness(1);
             // set it so its 1px offset in all directions (top left bottom right)
             whiteBorder.Margin = new Thickness(1);
@@ -274,9 +276,9 @@ namespace Aerochat.Controls
 
         private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
         {
-            switch (msg)
+            switch ((WindowMessage)msg)
             {
-                case 0x84: // WM_NCHITTEST
+                case WM_NCHITTEST:
                 {
                     System.Windows.Point point = PointFromNcHit(lParam);
 
@@ -299,17 +301,17 @@ namespace Aerochat.Controls
                                 // should always work and yet somehow it doesn't. This hack is
                                 // a workaround so the icon behaves like native windows do.
 
-                                return 2; // HTCAPTION
+                                return (nint)HitTestValues.HTCAPTION;
                             }
 
-                            return 3; // HTSYSMENU
+                            return (nint)HitTestValues.HTSYSMENU;
                         }
                     }
 
                     break;
                 }
 
-                case 0xA4: // WM_NCRBUTTONDOWN
+                case WM_NCRBUTTONDOWN:
                 {
                     System.Windows.Point point = PointFromNcHit(lParam);
 
@@ -333,7 +335,7 @@ namespace Aerochat.Controls
                     break;
                 }
 
-                case 0xA5: // WM_NCRBUTTONUP
+                case WM_NCRBUTTONUP:
                 {
                     System.Windows.Point point = PointFromNcHit(lParam);
 
@@ -367,7 +369,7 @@ namespace Aerochat.Controls
                     break;
                 }
 
-                case 0x31E: // WM_DWMCOMPOSITIONCHANGED
+                case WM_DWMCOMPOSITIONCHANGED:
                 {
                     DwmIsCompositionEnabled(out bool enabled);
                     if (enabled != IsDwmEnabled)
@@ -378,7 +380,7 @@ namespace Aerochat.Controls
                     OnDwmChanged();
                     break;
                 }
-                case 0x000C: // WM_SETTEXT
+                case WM_SETTEXT:
                 {
                     string? newText = Marshal.PtrToStringAuto(wParam);
                     if (newText != null)

--- a/Aerochat/Controls/NativeToolTip.cs
+++ b/Aerochat/Controls/NativeToolTip.cs
@@ -19,6 +19,8 @@ using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows;
 using System.Diagnostics;
+using Vanara.PInvoke;
+using static Vanara.PInvoke.User32;
 using static System.Net.Mime.MediaTypeNames;
 
 namespace Aerochat.Controls
@@ -29,17 +31,6 @@ namespace Aerochat.Controls
 
         [DllImport("user32.dll", SetLastError = true)]
         private static extern IntPtr CreateWindowEx(WindowStylesEx dwExStyle, string lpClassName, string lpWindowName, uint dwStyle, int x, int y, int nWidth, int nHeight, IntPtr hWndParent, IntPtr hMenu, IntPtr hInstance, IntPtr lpParam);
-
-        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool DestroyWindow(IntPtr hwnd);
-
-        [DllImport("user32.dll")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, SetWindowPosFlags uFlags);
-
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        private static extern IntPtr SendMessage(IntPtr hWnd, UInt32 Msg, IntPtr wParam, IntPtr lParam);
 
         private const int CW_USEDEFAULT = unchecked((int)0x80000000);
 
@@ -58,64 +49,6 @@ namespace Aerochat.Controls
             [MarshalAs(UnmanagedType.LPTStr)]
             public string lpszText;
             public IntPtr lParam;
-        }
-
-        [Flags]
-        private enum WindowStylesEx : uint
-        {
-            WS_EX_ACCEPTFILES = 0x00000010,
-            WS_EX_APPWINDOW = 0x00040000,
-            WS_EX_CLIENTEDGE = 0x00000200,
-            WS_EX_COMPOSITED = 0x02000000,
-            WS_EX_CONTEXTHELP = 0x00000400,
-            WS_EX_CONTROLPARENT = 0x00010000,
-            WS_EX_DLGMODALFRAME = 0x00000001,
-            WS_EX_LAYERED = 0x00080000,
-            WS_EX_LAYOUTRTL = 0x00400000,
-            WS_EX_LEFT = 0x00000000,
-            WS_EX_LEFTSCROLLBAR = 0x00004000,
-            WS_EX_LTRREADING = 0x00000000,
-            WS_EX_MDICHILD = 0x00000040,
-            WS_EX_NOACTIVATE = 0x08000000,
-            WS_EX_NOINHERITLAYOUT = 0x00100000,
-            WS_EX_NOPARENTNOTIFY = 0x00000004,
-            WS_EX_OVERLAPPEDWINDOW = WS_EX_WINDOWEDGE | WS_EX_CLIENTEDGE,
-            WS_EX_PALETTEWINDOW = WS_EX_WINDOWEDGE | WS_EX_TOOLWINDOW | WS_EX_TOPMOST,
-            WS_EX_RIGHT = 0x00001000,
-            WS_EX_RIGHTSCROLLBAR = 0x00000000,
-            WS_EX_RTLREADING = 0x00002000,
-            WS_EX_STATICEDGE = 0x00020000,
-            WS_EX_TOOLWINDOW = 0x00000080,
-            WS_EX_TOPMOST = 0x00000008,
-            WS_EX_TRANSPARENT = 0x00000020,
-            WS_EX_WINDOWEDGE = 0x00000100
-        }
-
-        [Flags]
-        private enum WindowStyles : uint
-        {
-            WS_BORDER = 0x800000,
-            WS_CAPTION = 0xc00000,
-            WS_CHILD = 0x40000000,
-            WS_CLIPCHILDREN = 0x2000000,
-            WS_CLIPSIBLINGS = 0x4000000,
-            WS_DISABLED = 0x8000000,
-            WS_DLGFRAME = 0x400000,
-            WS_GROUP = 0x20000,
-            WS_HSCROLL = 0x100000,
-            WS_MAXIMIZE = 0x1000000,
-            WS_MAXIMIZEBOX = 0x10000,
-            WS_MINIMIZE = 0x20000000,
-            WS_MINIMIZEBOX = 0x20000,
-            WS_OVERLAPPED = 0x0,
-            WS_OVERLAPPEDWINDOW = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_SIZEFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX,
-            WS_POPUP = 0x80000000u,
-            WS_POPUPWINDOW = WS_POPUP | WS_BORDER | WS_SYSMENU,
-            WS_SIZEFRAME = 0x40000,
-            WS_SYSMENU = 0x80000,
-            WS_TABSTOP = 0x10000,
-            WS_VISIBLE = 0x10000000,
-            WS_VSCROLL = 0x200000
         }
 
         [Flags]
@@ -190,35 +123,6 @@ namespace Aerochat.Controls
             TTM_SETTITLEW = WM_USER + 33,  // wParam = TTI_*, lParam = wchar* szTitle
             TTM_POPUP = WM_USER + 34,
             TTM_GETTITLE = WM_USER + 35 // wParam = 0, lParam = TTGETTITLE*
-        }
-
-        [Flags]
-        private enum SetWindowPosFlags : uint
-        {
-            SWP_NOSIZE = 0x0001,
-            SWP_NOMOVE = 0x0002,
-            SWP_NOZORDER = 0x0004,
-            SWP_NOREDRAW = 0x0008,
-            SWP_NOACTIVATE = 0x0010,
-            SWP_DRAWFRAME = 0x0020,
-            SWP_FRAMECHANGED = 0x0020,
-            SWP_SHOWWINDOW = 0x0040,
-            SWP_HIDEWINDOW = 0x0080,
-            SWP_NOCOPYBITS = 0x0100,
-            SWP_NOOWNERZORDER = 0x0200,
-            SWP_NOREPOSITION = 0x0200,
-            SWP_NOSENDCHANGING = 0x0400,
-            SWP_DEFERERASE = 0x2000,
-            SWP_ASYNCWINDOWPOS = 0x4000
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct RECT
-        {
-            public int left;
-            public int top;
-            public int right;
-            public int bottom;
         }
 
         #endregion
@@ -353,11 +257,6 @@ namespace Aerochat.Controls
 
         public const int GCL_STYLE = -26;
         public const int CS_DROPSHADOW = 0x20000;
-
-        [DllImport("user32.dll", EntryPoint = "GetClassLong")]
-        public static extern int GetClassLong(IntPtr hWnd, int nIndex);
-        [DllImport("user32.dll", EntryPoint = "SetClassLong")]
-        public static extern int SetClassLong(IntPtr hWnd, int nIndex, int dwNewLong);
 
         private static void Add(IntPtr handle)
         {

--- a/Aerochat/FontAppearanceManager.cs
+++ b/Aerochat/FontAppearanceManager.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Media;
+using Vanara.PInvoke;
 using static Vanara.PInvoke.User32;
 
 namespace Aerochat
@@ -17,6 +18,9 @@ namespace Aerochat
     {
         private static FontAppearanceManager _instance;
         private TextRenderingMode _textRenderingMode = TextRenderingMode.Auto;
+
+        private const int FE_FONTSMOOTHINGSTANDARD = 1;
+        private const int FE_FONTSMOOTHINGCLEARTYPE = 2;
 
         public static FontAppearanceManager Instance
         {
@@ -54,8 +58,7 @@ namespace Aerochat
         /// </remarks>
         public void Refresh()
         {
-            bool bFontSmoothingEnabled = false;
-            bool spiResult = SystemParametersInfo(SPI_GETFONTSMOOTHING, 0, ref bFontSmoothingEnabled, false);
+            bool spiResult = SystemParametersInfo(SPI.SPI_GETFONTSMOOTHING, out bool bFontSmoothingEnabled);
 
             if (!spiResult)
             {
@@ -78,8 +81,8 @@ namespace Aerochat
 
             // Otherwise, check the user's font smoothing type:
 
-            int uiType = FE_FONTSMOOTHINGSTANDARD;
-            spiResult = SystemParametersInfo(SPI_GETFONTSMOOTHINGTYPE, 0, ref uiType, false);
+            uint uiType = FE_FONTSMOOTHINGSTANDARD;
+            spiResult = SystemParametersInfo(SPI.SPI_GETFONTSMOOTHINGTYPE, out uiType);
 
             if (!spiResult)
             {
@@ -111,18 +114,5 @@ namespace Aerochat
                 _textRenderingMode = TextRenderingMode.Auto;
             }
         }
-
-        private const int SPI_GETFONTSMOOTHING = 0x004A;
-        private const int SPI_GETFONTSMOOTHINGTYPE = 0x200A;
-        private const int FE_FONTSMOOTHINGSTANDARD = 1;
-        private const int FE_FONTSMOOTHINGCLEARTYPE = 2;
-
-        [DllImport("user32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        static extern bool SystemParametersInfo(int uiAction, uint uiParam, ref bool pvParam, bool fWinIni);
-
-        [DllImport("user32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        static extern bool SystemParametersInfo(int uiAction, uint uiParam, ref int pvParam, bool fWinIni);
     }
 }


### PR DESCRIPTION
*Excluding some things that weren't working right with it, like the CreateWindowEx import in the native tooltip library.