### PR TITLE
feat: Option to Hide Community Images (#25)

### DIFF
--- a/Aerochat/Converter/BooleanToVisibilityConverter.cs
+++ b/Aerochat/Converter/BooleanToVisibilityConverter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Aerochat.Windows
+{
+    public class BooleanToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool boolValue)
+            {
+                return boolValue ? Visibility.Visible : Visibility.Collapsed;
+            }
+            return Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is Visibility visibilityValue)
+            {
+                return visibilityValue == Visibility.Visible;
+            }
+            return false;
+        }
+    }
+}

--- a/Aerochat/Settings/SettingsManager.cs
+++ b/Aerochat/Settings/SettingsManager.cs
@@ -99,6 +99,10 @@ namespace Aerochat.Settings
 
         [Settings("Appearance", "Use the Windows XP caption button theme in non-native titlebar")]
         public bool XPCaptionButtons { get; set; } = false;
+
+        [Settings("Appearance", "Show community images in the Main View (requires restart)")]
+
+        public bool DisplayAds { get; set; } = true;
         #endregion
     }
 }

--- a/Aerochat/Windows/Home.xaml
+++ b/Aerochat/Windows/Home.xaml
@@ -15,6 +15,7 @@
         <TaskbarItemInfo x:Name="TaskbarInfo" />
     </Window.TaskbarItemInfo>
     <Window.Resources>
+        <local:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         <Storyboard x:Key="FadeOutStoryboard">
             <DoubleAnimation Storyboard.TargetProperty="Opacity"
                              To="0"
@@ -854,7 +855,7 @@
                                 </Grid>
                                 <Grid Grid.Row="1" UseLayoutRounding="True">
                                     <Border Width="Auto" Height="Auto" HorizontalAlignment="Left" VerticalAlignment="Bottom" BorderThickness="1" BorderBrush="Black">
-                                        <Image Stretch="Fill" PreviewMouseLeftButtonDown="Image_PreviewMouseLeftButtonDown" PreviewMouseRightButtonDown="Image_PreviewMouseRightButtonDown" RenderOptions.BitmapScalingMode="HighQuality" MaxWidth="234" Height="60" Grid.Column="1" Source="{Binding Ad.Image, Mode=OneWay}">
+                                        <Image x:Name="AdImage" Stretch="Fill" PreviewMouseLeftButtonDown="Image_PreviewMouseLeftButtonDown" PreviewMouseRightButtonDown="Image_PreviewMouseRightButtonDown" RenderOptions.BitmapScalingMode="HighQuality" MaxWidth="234" Height="60" Grid.Column="1" Source="{Binding Ad.Image, Mode=OneWay}">
                                             <Image.Style>
                                                 <Style TargetType="Image">
                                                     <Setter Property="Cursor" Value="Hand" />

--- a/Aerochat/Windows/Home.xaml.cs
+++ b/Aerochat/Windows/Home.xaml.cs
@@ -50,7 +50,15 @@ namespace Aerochat.Windows
                 DataContext = ViewModel;
                 Loaded += HomeListView_Loaded;
                 Client_Ready(Discord.Client, null);
+
+                // Set visibility of the ad based on settings
+                UpdateAdVisibility();
             });
+        }
+
+        private void UpdateAdVisibility()
+        {
+            AdImage.Visibility = SettingsManager.Instance.DisplayAds ? Visibility.Visible : Visibility.Collapsed;
         }
 
         public void UpdateUnreadMessages()


### PR DESCRIPTION
This commit will allow the option for users to disable the community images (also misleadingly called "ads") 
_marked in blue in the screenshot attached_

the change will apply after a restart.
i do apologize if i violated a pattern -- i work with c# as my job, we use MVVM. I'm not used to put stuff in the code-behind.

![grafik](https://github.com/user-attachments/assets/ae06a985-0a79-4a7f-b9c3-c75f81aabacc)

