### PR TITLE
feat: Change Time from "American (AM/PM)" to "MilitaryTime/European (HH:mm)" option (#58) and DisplayAttribute for Enums in Settings (#61)

### DIFF
--- a/Aerochat/Attributes/DisplayAttribute.cs
+++ b/Aerochat/Attributes/DisplayAttribute.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+// (iL - 21.12.2024) This is basically another abstraction layer for developers.
+// Let's say you have a beautiful DropDown for the Settings, but your Enum Variable Names are pretty cryptic
+// for the average End-User. With Aerochat.Attributes, you can show the user a beautiful string in the UI,
+// while here in the Code you can keep your cryptic and scary sounding Names.
+
+namespace Aerochat.Attributes
+{
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+    public class DisplayAttribute : Attribute
+    {
+        public string Name { get; set;  }
+
+        public DisplayAttribute(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/Aerochat/Converter/EnumToStringConverter.cs
+++ b/Aerochat/Converter/EnumToStringConverter.cs
@@ -1,0 +1,53 @@
+﻿using Aerochat.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace Aerochat.Windows
+{
+    public class EnumToStringConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+                return string.Empty;  // Default empty string for no selection
+
+            if (value is Enum enumValue)
+            {
+                var fieldInfo = enumValue.GetType().GetField(enumValue.ToString());
+                var displayAttribute = fieldInfo?.GetCustomAttribute<DisplayAttribute>();
+                return displayAttribute?.Name ?? enumValue.ToString();
+            }
+
+            return value.ToString();
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            // Handle conversion back from the display name to enum
+            if (value == null || string.IsNullOrEmpty(value.ToString()))
+                return null;
+
+            try
+            {
+                var enumType = targetType;
+                var enumValue = Enum.GetValues(enumType)
+                                    .Cast<Enum>()
+                                    .FirstOrDefault(e => e.GetType()
+                                                          .GetField(e.ToString())
+                                                          ?.GetCustomAttribute<DisplayAttribute>()?.Name == value.ToString());
+
+                return enumValue;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Aerochat/Converter/TimeFormatConverter.cs
+++ b/Aerochat/Converter/TimeFormatConverter.cs
@@ -1,0 +1,33 @@
+﻿using Aerochat.Enums;
+using Aerochat.Settings;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace Aerochat.Windows
+{
+    public class TimeFormatConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is DateTime dateTime)
+            {
+                // Retrieve SelectedTimeFormat from the SettingsManager
+                var format = SettingsManager.Instance.SelectedTimeFormat;
+                string formatString = format == TimeFormat.TwentyFourHour ? "HH:mm:ss" : "h:mm tt";
+
+                return dateTime.ToString(formatString);
+            }
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Aerochat/Enums/TimeFormat.cs
+++ b/Aerochat/Enums/TimeFormat.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Aerochat.Attributes;
+
+namespace Aerochat.Enums
+{
+    public enum TimeFormat
+    {
+        [Display("24-Hour Clock")]
+        TwentyFourHour,
+
+        [Display("12-Hour Clock (AM/PM)")]
+        TwelveHour
+    }
+}

--- a/Aerochat/Helpers/EnumHelper.cs
+++ b/Aerochat/Helpers/EnumHelper.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Aerochat.Attributes;
+
+namespace Aerochat.Helpers
+{
+    public static class EnumHelper
+    {
+        public static string GetDisplayName(Enum enumValue)
+        {
+            var fieldInfo = enumValue.GetType()
+                .GetField(enumValue.ToString(), BindingFlags.Public | BindingFlags.Static);
+
+            if (fieldInfo != null)
+            {
+                var displayAttribute = fieldInfo.GetCustomAttribute<DisplayAttribute>();
+
+                if (displayAttribute != null)
+                {
+                    return displayAttribute.Name;
+                }
+            }
+
+            return enumValue.ToString();
+        }
+
+        public static List<(string DisplayName, T EnumValue)> GetEnumDisplayList<T>() where T : Enum
+        {
+            return Enum.GetValues(typeof(T))
+                .Cast<T>()
+                .Select(e => (GetDisplayName(e), e))  // Create tuple of DisplayName and EnumValue
+                .ToList();
+        }
+    }
+}

--- a/Aerochat/Settings/SettingsManager.cs
+++ b/Aerochat/Settings/SettingsManager.cs
@@ -1,4 +1,5 @@
-﻿using Aerochat.ViewModels;
+﻿using Aerochat.Enums;
+using Aerochat.ViewModels;
 using System;
 using System.IO;
 using System.Linq;
@@ -103,6 +104,9 @@ namespace Aerochat.Settings
         [Settings("Appearance", "Show community-submitted ads on the home page")]
 
         public bool DisplayAds { get; set; } = true;
+
+        [Settings("Appearance", "Time format")]
+        public TimeFormat SelectedTimeFormat { get; set; } = TimeFormat.TwentyFourHour;
         #endregion
     }
 }

--- a/Aerochat/ViewModels/Base.cs
+++ b/Aerochat/ViewModels/Base.cs
@@ -22,6 +22,11 @@ namespace Aerochat.ViewModels
     {
         public event PropertyChangedEventHandler? PropertyChanged;
 
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
         protected bool SetProperty<T>(ref T field, T newValue, [CallerMemberName] string? propertyName = null)
         {
             if (!EqualityComparer<T>.Default.Equals(field, newValue))

--- a/Aerochat/ViewModels/Message.cs
+++ b/Aerochat/ViewModels/Message.cs
@@ -1,10 +1,14 @@
-﻿using Aerochat.Hoarder;
+﻿using Aerochat.Enums;
+using Aerochat.Hoarder;
+using Aerochat.Settings;
 using DSharpPlus;
 using DSharpPlus.Entities;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -16,7 +20,6 @@ namespace Aerochat.ViewModels
         private UserViewModel? _author;
         private string _message;
         private string _rawMessage;
-        private DateTime _timestamp;
         private ulong? _id;
         private bool _ephemeral = false;
         private bool _special = false;
@@ -42,11 +45,6 @@ namespace Aerochat.ViewModels
         {
             get => _rawMessage;
             set => SetProperty(ref _rawMessage, value);
-        }
-        public DateTime Timestamp
-        {
-            get => _timestamp;
-            set => SetProperty(ref _timestamp, value);
         }
         public ulong? Id
         {
@@ -92,6 +90,42 @@ namespace Aerochat.ViewModels
         {
             get => _messageEntity;
             set => SetProperty(ref _messageEntity, value);
+        }
+
+        public string TimestampString
+        {
+            get
+            {
+                var format = SettingsManager.Instance.SelectedTimeFormat == TimeFormat.TwentyFourHour ? "HH:mm" : "h:mm tt";
+                return Timestamp.ToString(format, CultureInfo.InvariantCulture);  // Ensure InvariantCulture to control formatting: Otherwise we will lose the AM/PM at the end!
+            }
+        }
+
+        private DateTime _timestamp;
+        public DateTime Timestamp
+        {
+            get { return _timestamp; }
+            set
+            {
+                if (_timestamp != value)
+                {
+                    _timestamp = value;
+                    RaisePropertyChanged(nameof(Timestamp));
+                    RaisePropertyChanged(nameof(TimestampString));
+                }
+            }
+        }
+
+        public virtual void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public void RaisePropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         public ObservableCollection<AttachmentViewModel> Attachments { get; } = new();

--- a/Aerochat/ViewModels/Settings.cs
+++ b/Aerochat/ViewModels/Settings.cs
@@ -1,9 +1,12 @@
-﻿using System;
+﻿using Aerochat.Enums;
+using Aerochat.Helpers;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static Vanara.PInvoke.ShlwApi;
 
 namespace Aerochat.ViewModels
 {
@@ -12,6 +15,10 @@ namespace Aerochat.ViewModels
         private string _type;
         private string _name;
         private string _defaultValue;
+
+        public ObservableCollection<string> EnumValues { get; set; } = new ObservableCollection<string>();
+        public ObservableCollection<string> TimeFormatOptions { get; set; }
+        public TimeFormat SelectedTimeFormat { get; set; }
 
         public string Type
         {
@@ -27,6 +34,17 @@ namespace Aerochat.ViewModels
         {
             get => _defaultValue;
             set => SetProperty(ref _defaultValue, value);
+        }
+
+        private string _selectedEnumValue;
+        public string SelectedEnumValue
+        {
+            get => _selectedEnumValue;
+            set
+            {
+                _selectedEnumValue = value;
+                OnPropertyChanged();
+            }
         }
     }
 

--- a/Aerochat/Windows/Chat.xaml
+++ b/Aerochat/Windows/Chat.xaml
@@ -50,7 +50,9 @@
         </Style>
     </Window.Style>
     <Window.Resources>
-        <Storyboard x:Key="FadeOutStoryboard">
+        <local:TimeFormatConverter x:Key="TimeFormatConverter"/>
+
+            <Storyboard x:Key="FadeOutStoryboard">
             <DoubleAnimation Storyboard.TargetProperty="Opacity"
                              To="0"
                              Duration="0:0:0.3"
@@ -909,7 +911,10 @@
                                                         </Image.Style>
                                                     </Image>
                                                     <TextBlock FontSize="13" Grid.Row="0" Text=" said (" Foreground="#525252" />
-                                                    <TextBlock FontSize="13" Grid.Row="0" Text="{Binding Timestamp, StringFormat=HH:mm}" Foreground="#525252" />
+                                                    <!--<TextBlock FontSize="13" Grid.Row="0" Text="{Binding Timestamp, StringFormat=HH:mm:ss}" Foreground="#525252" />-->
+                                                    <TextBlock FontSize="13" Foreground="#525252">
+                                                    <TextBlock FontSize="13" Grid.Row="0" Text="{Binding TimestampString}" Foreground="#525252" />
+                                                    </TextBlock>
                                                     <TextBlock FontSize="13" Grid.Row="0" Text="):" Foreground="#525252" />
                                                 </StackPanel>
                                             </StackPanel>

--- a/Aerochat/Windows/Settings.xaml
+++ b/Aerochat/Windows/Settings.xaml
@@ -113,6 +113,7 @@
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <Grid Margin="0,4,0,0">
+                            <!-- For Boolean Settings -->
                             <StackPanel Orientation="Horizontal">
                                 <StackPanel.Style>
                                     <Style TargetType="StackPanel">
@@ -128,6 +129,8 @@
                                     <TextBlock Text="{Binding Name}" />
                                 </CheckBox>
                             </StackPanel>
+
+                            <!-- For Integer Settings -->
                             <StackPanel>
                                 <StackPanel.Style>
                                     <Style TargetType="StackPanel">
@@ -142,8 +145,32 @@
                                 <TextBlock Margin="0,8,0,4" Text="{Binding Name}" />
                                 <TextBox TextChanged="TextBox_TextChanged" Tag="{Binding Name}" Text="{Binding DefaultValue}" PreviewTextInput="TextBox_PreviewTextInput" VerticalContentAlignment="Center" Width="150" Height="22" HorizontalAlignment="Left" />
                             </StackPanel>
+
+                            <!-- For Enum Settings -->
+                            <StackPanel>
+                                <StackPanel.Style>
+                                    <Style TargetType="StackPanel">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Type}" Value="Enum">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </StackPanel.Style>
+                                <TextBlock Margin="0,8,0,4" Text="{Binding Name}" />
+                                <ComboBox 
+       SelectionChanged="ComboBox_SelectionChanged" 
+       SelectedItem="{Binding SelectedEnumValue, Mode=TwoWay}" 
+                                    Tag="{Binding Name}"
+       ItemsSource="{Binding EnumValues}" 
+       Width="150" 
+       Height="22" 
+       HorizontalAlignment="Left" />
+                            </StackPanel>
                         </Grid>
                     </DataTemplate>
+
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
         </Grid>

--- a/Aerochat/Windows/Settings.xaml.cs
+++ b/Aerochat/Windows/Settings.xaml.cs
@@ -16,6 +16,8 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using Vanara.PInvoke;
+using Aerochat.Attributes;
+using System.Collections.ObjectModel;
 
 namespace Aerochat.Windows
 {
@@ -45,21 +47,51 @@ namespace Aerochat.Windows
             }
         }
 
+        private string GetEnumDisplayName(Enum enumValue)
+        {
+            // Get the field corresponding to the enum value
+            var field = enumValue.GetType().GetField(enumValue.ToString());
+            // Get the DisplayAttribute from the field
+            var attribute = (DisplayAttribute)Attribute.GetCustomAttribute(field, typeof(DisplayAttribute));
+
+            return attribute?.Name ?? enumValue.ToString(); // Return the display name or the enum value if no display name is found
+        }
+
         public List<SettingViewModel> GetSettingsFromCategory(string category)
         {
             var properties = SettingsManager.Instance.GetType()
                 .GetProperties()
                 .Where(prop => prop.GetCustomAttribute<SettingsAttribute>()?.Category == category);
+
             var settings = new List<SettingViewModel>();
+
             foreach (var prop in properties)
             {
-                settings.Add(new SettingViewModel
+                if (prop.PropertyType.IsEnum)
                 {
-                    Name = prop.GetCustomAttribute<SettingsAttribute>()!.DisplayName,
-                    Type = prop.PropertyType.Name,
-                    DefaultValue = prop.GetValue(SettingsManager.Instance).ToString()
-                });
+                    // Get the enum values as strings
+                    var enumValues = Enum.GetNames(prop.PropertyType).ToList();
+
+                    settings.Add(new SettingViewModel
+                    {
+                        Name = prop.GetCustomAttribute<SettingsAttribute>()!.DisplayName,
+                        Type = "Enum",
+                        DefaultValue = prop.GetValue(SettingsManager.Instance)?.ToString(),
+                        EnumValues = new ObservableCollection<string>(enumValues),
+                        SelectedEnumValue = prop.GetValue(SettingsManager.Instance)?.ToString()
+                    });
+                }
+                else
+                {
+                    settings.Add(new SettingViewModel
+                    {
+                        Name = prop.GetCustomAttribute<SettingsAttribute>()!.DisplayName,
+                        Type = prop.PropertyType.Name,
+                        DefaultValue = prop.GetValue(SettingsManager.Instance)?.ToString()
+                    });
+                }
             }
+
             return settings;
         }
 
@@ -113,6 +145,28 @@ namespace Aerochat.Windows
             if (property!.PropertyType != typeof(bool)) return;
             property!.SetValue(SettingsManager.Instance, checkBox.IsChecked);
             // save the settings
+            SettingsManager.Save();
+        }
+
+        private void ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var comboBox = (ComboBox)sender;
+            var name = comboBox.Tag.ToString();
+            var selectedValue = comboBox.SelectedItem.ToString();
+
+            // Find the corresponding property in SettingsManager
+            var property = SettingsManager.Instance.GetType()
+                .GetProperties()
+                .FirstOrDefault(prop => prop.GetCustomAttribute<SettingsAttribute>()?.DisplayName == name);
+
+            // If it's an Enum, set the value
+            if (property!.PropertyType.IsEnum)
+            {
+                var enumValue = Enum.Parse(property.PropertyType, selectedValue!);
+                property.SetValue(SettingsManager.Instance, enumValue);
+            }
+
+            // Save the settings
             SettingsManager.Save();
         }
     }


### PR DESCRIPTION
After several days of work, I’m excited to share an update. This has been quite an interesting experience for me.

While working on #58 , I added a new feature to the SettingsManager: an Enum represented as a ComboBox. Inspired by @kawapure's suggestion, I also implemented a DisplayAttribute. This attribute allows developers to display a user-friendly string for Enum values instead of the internal variable names (e.g., "MilitaryTime" becomes "24-hour clock").

Now, when developers want to represent an Enum in the UI via a ComboBox, they can use the [Display("12-Hour Clock (AM/PM)")] attribute (or a similar custom label) above each Enum item. This enhances the UI by presenting more intuitive labels to the user.
