### PR TITLE
feat: Read notifications using Text to Speech

### DIFF
--- a/Aerochat/Aerochat.csproj
+++ b/Aerochat/Aerochat.csproj
@@ -568,6 +568,7 @@
 		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2739.15" />
 		<PackageReference Include="MimeTypeMapOfficial" Version="1.0.17" />
 		<PackageReference Include="System.Drawing.Common" Version="8.0.8" />
+		<PackageReference Include="System.Speech" Version="9.0.4" />
 		<PackageReference Include="Vanara.PInvoke.DwmApi" Version="4.0.3" />
 		<PackageReference Include="Vanara.PInvoke.Shell32" Version="4.0.3" />
 		<PackageReference Include="Vanara.PInvoke.User32" Version="4.0.3" />

--- a/Aerochat/Settings/SettingsManager.cs
+++ b/Aerochat/Settings/SettingsManager.cs
@@ -173,6 +173,12 @@ namespace Aerochat.Settings
         [Settings("Alerts", "Play notification sounds")]
         public bool PlayNotificationSounds { get; set; } = true;
 
+        [Settings("Alerts", "Read message notifications")]
+        public bool ReadMessageNotifications { get; set; } = false;
+
+        [Settings("Alerts", "Read online notifications")]
+        public bool ReadOnlineNotifications { get; set; } = false;
+
         [Settings("Alerts", "Nudge intensity")]
         public int NudgeIntensity { get; set; } = 10;
 

--- a/Aerochat/Windows/Notification.xaml.cs
+++ b/Aerochat/Windows/Notification.xaml.cs
@@ -134,6 +134,7 @@ namespace Aerochat.Windows
                 Opacity = endOpacity;
             });
 
+            synth.Dispose();
             Close();
         }
 


### PR DESCRIPTION
Thought this would be a fun (and actually kinda useful) feature to add.

Uses the `System.Speech` package to read out message notifications and "user has just signed in." notifications. Also has settings to disable reading message and signed in notifications (defaults to off).

https://github.com/user-attachments/assets/7ca79840-58a2-4314-83e4-ed6d50112ab0

