### PR TITLE
Add option to toggle image preview visibility in chat links

### DIFF
--- a/Aerochat/Settings/SettingsManager.cs
+++ b/Aerochat/Settings/SettingsManager.cs
@@ -212,6 +212,10 @@ namespace Aerochat.Settings
 
         public bool DisplayAerochatAttribution { get; set; } = true;
 
+        [Settings("Appearance", "Show link previews in chat")]
+
+        public bool DisplayLinkPreviews { get; set; } = true;
+
         [Settings("Appearance", "Time format")]
         public TimeFormat SelectedTimeFormat { get; set; } = TimeFormat.TwentyFourHour;
 

--- a/Aerochat/ViewModels/Message.cs
+++ b/Aerochat/ViewModels/Message.cs
@@ -175,9 +175,13 @@ namespace Aerochat.ViewModels
                 MessageEntity = message,
                 IsTTS = message.IsTTS
             };
-            foreach (var embed in message.Embeds)
+
+            if (SettingsManager.Instance.DisplayLinkPreviews)
             {
-                vm.Embeds.Add(EmbedViewModel.FromEmbed(embed));
+                foreach (var embed in message.Embeds)
+                {
+                    vm.Embeds.Add(EmbedViewModel.FromEmbed(embed));
+                }
             }
 
             // TO ANY DEVELOPER LOOKING AT THIS, THINKING "WHERE IS THIS CRASHING??"


### PR DESCRIPTION
Added DisplayLinkPreviews boolean in SettingsManager.cs to show option in menu
Added DisplayLinkPreviews in Message.cs to control the visibility of image previews in chat

![image](https://github.com/user-attachments/assets/2667c6a6-d9b5-428b-804c-2919fdbf364a)
