### PR TITLE
Resolved some UI jank

### DIFF
--- a/Aerochat/Windows/About.xaml
+++ b/Aerochat/Windows/About.xaml
@@ -8,7 +8,7 @@
         mc:Ignorable="d"
         Title="About" Height="400" Width="500"
         ResizeMode="NoResize"
-        Style="{StaticResource Window}">
+        Style="{StaticResource Window}" WindowStartupLocation="CenterScreen">
     <controls:BaseTitlebar BlackText="Black">
         <Grid>
             <Grid.Background>

--- a/Aerochat/Windows/AerochatWindow.xaml
+++ b/Aerochat/Windows/AerochatWindow.xaml
@@ -6,6 +6,10 @@
         xmlns:local="clr-namespace:Aerochat.Windows"
         mc:Ignorable="d" Width="800" Height="450">
     <Grid>
-        <ContentControl x:Name="WindowContent" />
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="47*"/>
+            <ColumnDefinition Width="113*"/>
+        </Grid.ColumnDefinitions>
+        <ContentControl x:Name="WindowContent" Grid.ColumnSpan="2" />
     </Grid>
 </Window>

--- a/Aerochat/Windows/DiscordLoginWV2.xaml
+++ b/Aerochat/Windows/DiscordLoginWV2.xaml
@@ -8,6 +8,10 @@
         mc:Ignorable="d"
         Title=".NET Passport Log-on" Height="500" Width="850">
     <Grid>
-        <wv2:WebView2 x:Name="LoginWebView" />
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="139*"/>
+            <ColumnDefinition Width="286*"/>
+        </Grid.ColumnDefinitions>
+        <wv2:WebView2 x:Name="LoginWebView" Grid.ColumnSpan="2" />
     </Grid>
 </Window>

--- a/Aerochat/Windows/Home.xaml
+++ b/Aerochat/Windows/Home.xaml
@@ -11,6 +11,8 @@
         PreviewKeyDown="Window_PreviewKeyDown"
         Closing="Window_Closing"
         Title="Windows Live Messenger" Height="650" Width="400"
+        MinWidth="300"
+        MinHeight="500"
         MouseDown="Window_MouseDown"
         Style="{StaticResource Window}">
     <Window.TaskbarItemInfo>

--- a/Aerochat/Windows/Home.xaml.cs
+++ b/Aerochat/Windows/Home.xaml.cs
@@ -172,7 +172,6 @@ namespace Aerochat.Windows
             return 0;
         }
 
-
         private async Task Client_Ready(DiscordClient sender, DSharpPlus.EventArgs.ReadyEventArgs args)
         {
             await Dispatcher.BeginInvoke(() =>

--- a/Aerochat/Windows/Login.xaml
+++ b/Aerochat/Windows/Login.xaml
@@ -8,7 +8,7 @@
         xmlns:converter="clr-namespace:Aerochat.Converter"
         mc:Ignorable="d"
         Title="Windows Live Messenger" Height="650" Width="400"
-        Style="{StaticResource Window}">
+        Style="{StaticResource Window}" ResizeMode="NoResize">
     <Window.Resources>
         <converter:MultiBooleanConverter x:Key="MultiBooleanConverter"/>
     </Window.Resources>

--- a/Aerochat/Windows/Settings.xaml
+++ b/Aerochat/Windows/Settings.xaml
@@ -7,7 +7,7 @@
         mc:Ignorable="d"
         Title="Settings" Height="570" Width="520"
         Background="#f0f0f0"
-        Style="{StaticResource Window}">
+        Style="{StaticResource Window}" WindowStartupLocation="CenterScreen">
     <Grid Margin="7">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="92" />


### PR DESCRIPTION
These changes stop some UI jank from happening during normal usage. Mainly the home and login window could be resized to the point where only the native titlebar and window controls were visible. 

The final changes I made were the About and Settings dialogue appearing in the centre of the screen as you want them to be front and centre as they are dialogues.