### PR TITLE
Improvement: Notification attachment counts + @unknown-user fix

### DIFF
--- a/Aerochat/Helpers/TextToSpeech.cs
+++ b/Aerochat/Helpers/TextToSpeech.cs
@@ -40,7 +40,9 @@ namespace Aerochat.Helpers
 
         public void ReadOutMessage(string message)
         {
-            _speechSynth?.SpeakAsync(message);
+            //Force text to always be in lowercase.
+            //Pronounciation of words in all uppercase with some voices (Microsoft Sam) spells out the word letter by letter (WOWZA -> W O W Z A)
+            _speechSynth?.SpeakAsync(message.ToLower());
         }
     }
 }

--- a/Aerochat/Windows/Notification.xaml.cs
+++ b/Aerochat/Windows/Notification.xaml.cs
@@ -208,7 +208,7 @@ namespace Aerochat.Windows
         {
             if (message.Attachments.Count > 0 && message.Content == String.Empty)
             {
-                return $"Uploaded {message.Attachments.Count} attachments.";
+                return $"Uploaded {message.Attachments.Count} attachment{(message.Attachments.Count == 1 ? '\0' : 's')}.";
             }
             else
             {

--- a/Aerochat/Windows/Notification.xaml.cs
+++ b/Aerochat/Windows/Notification.xaml.cs
@@ -157,17 +157,23 @@ namespace Aerochat.Windows
                     if (SettingsManager.Instance.ReadMessageNotifications && TextToSpeech.Instance.Available)
                     {
                         //Remove links from the TTS message so it doesn't ramble on forever.
-                        //also replaces # with "hashtag" so it doesnt say "number sign".
+                        //also replaces a few characters with different pronounciations
+
                         var FilteredMessage = "";
                         var SplitFilteredMessage = ViewModel.Message.Message.Split(' ');
                         foreach (var split in SplitFilteredMessage)
                         {
-                            if (split.StartsWith('#'))
+                            if (split.StartsWith('#')) //Pronounced as "number sign", replaced with "hashtag"
                             {
                                 string part = split.Replace("#", " hashtag");
                                 FilteredMessage += part;
                             }
-                            else if (split.StartsWith("http://") || split.StartsWith("https://"))
+                            else if (split.StartsWith('^')) //Pronounced as "circumflex accent", replaced with "caret"
+                            {
+                                string part = split.Replace("^", " caret");
+                                FilteredMessage += part;
+                            }
+                            else if (split.StartsWith("http://") || split.StartsWith("https://")) //Replace all links with "a link"
                             {
                                 FilteredMessage += " (a link)";
                             }

--- a/Aerochat/Windows/Notification.xaml.cs
+++ b/Aerochat/Windows/Notification.xaml.cs
@@ -15,6 +15,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using Aerochat.Settings;
+using Aerochat.Hoarder;
 
 namespace Aerochat.Windows
 {
@@ -231,7 +232,8 @@ namespace Aerochat.Windows
                             else
                             {
                                 ulong.TryParse(id, out ulong parsedId);
-                                var user = message.MentionedUsers?.FirstOrDefault(x => x?.Id == parsedId);
+                                var user = Discord.Client.GetUserProfileAsync(parsedId).GetAwaiter().GetResult().User;
+
                                 if (user == null)
                                     FilteredMessage += " @unknown-user";
                                 else


### PR DESCRIPTION
A minor additions and 2 fixes to notifications, both minor issues but small enough for me to care about fixing them.

- Notifications now show "Uploaded X attachment(s)" instead of an empty message if someone is only sending attachments.
- Fixed a bug where some user mentions would show @unknown-user in some cases (GDM mentions mostly)
- (text to speech related) `^` should now be pronounced as "carat" instead of "circumflex accent" when reading notifications

I also included an unrelated change where all text to speech output will be read in lowercase since messages in ALL UPPERCASE would sometimes be read letter by letter. Feel free to remove this one if you want to. 

<img width="241" height="326" alt="image" src="https://github.com/user-attachments/assets/298af4db-2a3c-4365-abf8-1da155528fb7" />

