### PR TITLE
Downgrade to .NET 6

### DIFF
--- a/Aerobool/Aerobool/Aerobool.csproj
+++ b/Aerobool/Aerobool/Aerobool.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Aerobool/Aerobool/Expressions/EqualsExpression.cs
+++ b/Aerobool/Aerobool/Expressions/EqualsExpression.cs
@@ -1,16 +1,17 @@
 ﻿using Aerobool.Interface;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Aerobool.Expressions
 {
-    public class EqualsExpression(IExpression left, IExpression right) : IExpression
+    public class EqualsExpression : IExpression
     {
-        public IExpression Left { get; set; } = left;
-        public IExpression Right { get; set; } = right;
+        public IExpression Left { get; }
+        public IExpression Right { get; }
+
+        public EqualsExpression(IExpression left, IExpression right)
+        {
+            Left = left;
+            Right = right;
+        }
 
         public object Evaluate(object? context)
         {

--- a/Aerobool/Aerobool/Expressions/NotExpression.cs
+++ b/Aerobool/Aerobool/Expressions/NotExpression.cs
@@ -7,9 +7,14 @@ using System.Threading.Tasks;
 
 namespace Aerobool.Expressions
 {
-    public class NotExpression(IExpression expression) : IExpression
+    public class NotExpression : IExpression
     {
-        public IExpression Expression = expression;
+        public IExpression Expression;
+
+        public NotExpression(IExpression expression)
+        {
+            Expression = expression;
+        }
 
         public object Evaluate(object? context)
         {

--- a/Aerobool/Aerobool/Expressions/TypecheckExpression.cs
+++ b/Aerobool/Aerobool/Expressions/TypecheckExpression.cs
@@ -7,10 +7,16 @@ using System.Threading.Tasks;
 
 namespace Aerobool.Expressions
 {
-    public class TypecheckExpression(IExpression left, IExpression right) : IExpression
+    public class TypecheckExpression : IExpression
     {
-        public IExpression Left { get; set; } = left;
-        public IExpression Right { get; set; } = right;
+        public IExpression Left { get; set; }
+        public IExpression Right { get; set; }
+
+        public TypecheckExpression(IExpression left, IExpression right)
+        {
+            Left = left;
+            Right = right;
+        }
 
         public object Evaluate(object? context)
         {

--- a/Aerobool/Aerobool/Expressions/ValueExpression.cs
+++ b/Aerobool/Aerobool/Expressions/ValueExpression.cs
@@ -7,9 +7,14 @@ using System.Threading.Tasks;
 
 namespace Aerobool.Expressions
 {
-    public class ValueExpression(object value) : IExpression
+    public class ValueExpression : IExpression
     {
-        public object Value { get; set; } = value;
+        public object Value { get; set; }
+
+        public ValueExpression(object value)
+        {
+            Value = value;
+        }
 
         public object Evaluate(object? context)
         {

--- a/Aerochat/Aerochat.csproj
+++ b/Aerochat/Aerochat.csproj
@@ -6,7 +6,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows7.0</TargetFramework>
+		<TargetFramework>net6.0-windows7.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWPF>true</UseWPF>

--- a/Aerochat/Aerochat.csproj
+++ b/Aerochat/Aerochat.csproj
@@ -662,7 +662,7 @@
 		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2739.15" />
 		<PackageReference Include="MimeTypeMapOfficial" Version="1.0.17" />
 		<PackageReference Include="System.Drawing.Common" Version="8.0.8" />
-		<PackageReference Include="System.Speech" Version="9.0.4" />
+		<PackageReference Include="System.Speech" Version="8.0.0" />
 		<PackageReference Include="Vanara.PInvoke.DwmApi" Version="4.0.3" />
 		<PackageReference Include="Vanara.PInvoke.Shell32" Version="4.0.3" />
 		<PackageReference Include="Vanara.PInvoke.User32" Version="4.0.3" />

--- a/Aerochat/App.xaml.cs
+++ b/Aerochat/App.xaml.cs
@@ -250,7 +250,7 @@ namespace Aerochat
             string result = reader.ReadToEnd();
             XDocument doc = XDocument.Parse(result);
 
-            foreach (XElement sceneXml in doc.Root?.Elements() ?? [])
+            foreach (XElement sceneXml in doc.Root?.Elements() ?? Enumerable.Empty<XElement>())
             {
                 SceneViewModel scene = SceneViewModel.FromScene(sceneXml);
                 var existing = ThemeService.Instance.Scenes.FirstOrDefault(x => x.Color == scene.Color);

--- a/Aerochat/BBCode/BBCodeToken.cs
+++ b/Aerochat/BBCode/BBCodeToken.cs
@@ -19,8 +19,8 @@ namespace Aerochat.BBCode
     {
         public BBCodeTokenType Type;
         public string Content;
-        public List<BBCodeToken> Children = [];
-        public Dictionary<string, string> Attributes = [];
+        public List<BBCodeToken> Children = new();
+        public Dictionary<string, string> Attributes = new();
         public BBCodeToken? Parent;
 
         public BBCodeToken(BBCodeTokenType type)

--- a/Aerochat/Controls/AttachmentsEditor/PopupBehavior.cs
+++ b/Aerochat/Controls/AttachmentsEditor/PopupBehavior.cs
@@ -495,8 +495,8 @@ namespace Aerochat.Controls.AttachmentsEditor
 
                     case WM_SIZE:
                     {
-                        int width = lParam.ToInt32() & 0xFFFF;
-                        int height = lParam.ToInt32() >> 16 & 0xFFFF;
+                        int width = (int)(lParam & 0xFFFF);
+                        int height = (int)(lParam >> 16 & 0xFFFF);
 
                         if (_isOptimizingMovement)
                         {
@@ -572,7 +572,7 @@ namespace Aerochat.Controls.AttachmentsEditor
                     }
 
                     User32.GetWindowRect(hWndPopup, out RECT rect);
-                    User32.MapWindowRect(0 /* HWND_DESKTOP */, hWndOwner, ref rect);
+                    User32.MapWindowRect(HWND.NULL /* HWND_DESKTOP */, hWndOwner, ref rect);
 
                     // We can't optimise movement if the popup window is larger than the owner,
                     // so we just rely on moving the window directly.

--- a/Aerochat/Controls/BasicTitlebar.cs
+++ b/Aerochat/Controls/BasicTitlebar.cs
@@ -411,7 +411,7 @@ namespace Aerochat.Controls
                 return lRes;
             }
 
-            return nint.Zero;
+            return IntPtr.Zero;
         }
 
         #region DLL imports
@@ -565,7 +565,7 @@ namespace Aerochat.Controls
                     if (_titlebarStyle == TitlebarStyle.Custom)
                     {
                         handled = true;
-                        return 0;
+                        return IntPtr.Zero;
                     }
                     break;
                 }

--- a/Aerochat/Controls/NativeToolTip.cs
+++ b/Aerochat/Controls/NativeToolTip.cs
@@ -266,9 +266,9 @@ namespace Aerochat.Controls
 
             SetWindowPos(_tooltipWindow, HWND_TOPMOST, 0, 0, 0, 0, SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOACTIVATE);
 
-            var cs = GetClassLong(_tooltipWindow, GCL_STYLE);
+            var cs = (int)GetClassLong(_tooltipWindow, GCL_STYLE);
             cs |= CS_DROPSHADOW;
-            SetClassLong(_tooltipWindow, GCL_STYLE, cs);
+            SetClassLong(_tooltipWindow, GCL_STYLE, (IntPtr)cs);
 
             _ti = new TOOLINFO();
             _ti.cbSize = Marshal.SizeOf(_ti);
@@ -287,7 +287,7 @@ namespace Aerochat.Controls
             // effectively disable the maximum width bound - line breaking can behave oddly otherwise
             SendToolTipMessage(ToolTipMessages.TTM_SETMAXTIPWIDTH, IntPtr.Zero, new IntPtr(short.MaxValue));
 
-            SendToolTipMessage(ToolTipMessages.TTM_SETDELAYTIME, new nint(3), IntPtr.Zero);
+            SendToolTipMessage(ToolTipMessages.TTM_SETDELAYTIME, new IntPtr(3), IntPtr.Zero);
 
             added = true;
         }

--- a/Aerochat/Controls/NineSliceStuff/NineSliceCacheManager.cs
+++ b/Aerochat/Controls/NineSliceStuff/NineSliceCacheManager.cs
@@ -20,7 +20,7 @@ internal class NineSliceCacheManager
 {
     public static NineSliceCacheManager Instance { get; private set; } = new();
 
-    private WeakDictionary<string, NineSliceImageSet> _entries = [];
+    private WeakDictionary<string, NineSliceImageSet> _entries = new();
 
     /// <summary>
     /// Attempts to find an already existing image set meeting the same parameters, or creates a new one

--- a/Aerochat/Converter/MultiBooleanConverter.cs
+++ b/Aerochat/Converter/MultiBooleanConverter.cs
@@ -21,7 +21,7 @@ namespace Aerochat.Converter
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         {
-            return [false];
+            return new object[] { false };
         }
     }
 }

--- a/Aerochat/Helpers/AttachmentEditor/ProgramIconManager.cs
+++ b/Aerochat/Helpers/AttachmentEditor/ProgramIconManager.cs
@@ -12,6 +12,7 @@ using System.Windows.Interop;
 using System.Windows.Media.Imaging;
 using static Vanara.PInvoke.User32;
 using static Vanara.PInvoke.Shell32;
+using Vanara.PInvoke;
 
 namespace Aerochat.Helpers.AttachmentEditor
 {
@@ -33,7 +34,7 @@ namespace Aerochat.Helpers.AttachmentEditor
                     SHGFI.SHGFI_ICON | SHGFI.SHGFI_USEFILEATTRIBUTES | SHGFI.SHGFI_LARGEICON
                 );
 
-                if (fileInfo.hIcon != 0)
+                if (fileInfo.hIcon != HICON.NULL)
                 {
                     BitmapSource result = Imaging.CreateBitmapSourceFromHIcon(
                         (nint)fileInfo.hIcon, Int32Rect.Empty, BitmapSizeOptions.FromWidthAndHeight(32, 32)
@@ -47,7 +48,7 @@ namespace Aerochat.Helpers.AttachmentEditor
             }
             finally
             {
-                if (fileInfo.hIcon != 0)
+                if (fileInfo.hIcon != HICON.NULL)
                 {
                     DestroyIcon(fileInfo.hIcon);
                 }

--- a/Aerochat/Hoarder/Hoarder.cs
+++ b/Aerochat/Hoarder/Hoarder.cs
@@ -17,8 +17,8 @@ namespace Aerochat.Hoarder
 
         public static bool Ready = false;
 
-        public static List<BitmapImage> ProfileFrames =
-        [
+        public static List<BitmapImage> ProfileFrames = new()
+        {
             new BitmapImage(new Uri("pack://application:,,,/Aerochat;component/Resources/Frames/LargeFrameActive.png")),
             new BitmapImage(new Uri("pack://application:,,,/Aerochat;component/Resources/Frames/LargeFrameActiveAnimation.png")),
             new BitmapImage(new Uri("pack://application:,,,/Aerochat;component/Resources/Frames/LargeFrameDnd.png")),
@@ -55,6 +55,6 @@ namespace Aerochat.Hoarder
             new BitmapImage(new Uri("pack://application:,,,/Aerochat;component/Resources/Frames/XSFrameIdleM.png")),
             new BitmapImage(new Uri("pack://application:,,,/Aerochat;component/Resources/Frames/XSFrameOffline.png")),
             new BitmapImage(new Uri("pack://application:,,,/Aerochat;component/Resources/Frames/XSFrameOfflineM.png")),
-        ];
+        };
     }
 }

--- a/Aerochat/Settings/SettingsManager.cs
+++ b/Aerochat/Settings/SettingsManager.cs
@@ -145,7 +145,7 @@ namespace Aerochat.Settings
         public DateTime ReadRecieptReference { get; set; } = DateTime.MinValue;
         public bool HasUserLoggedInBefore { get; set; } = false;
         public bool HasWarnedAboutVoiceChat { get; set; } = false;
-        public List<ulong> ViewedNotices { get; set; } = [];
+        public List<ulong> ViewedNotices { get; set; } = new();
 
         #endregion
 

--- a/Aerochat/ViewModels/AeroboolTreeItem.cs
+++ b/Aerochat/ViewModels/AeroboolTreeItem.cs
@@ -28,6 +28,6 @@ namespace Aerochat.ViewModels
             set => SetProperty(ref _value, value);
         }
 
-        public ObservableCollection<AeroboolTreeItemViewModel> Children { get; } = [];
+        public ObservableCollection<AeroboolTreeItemViewModel> Children { get; } = new();
     }
 }

--- a/Aerochat/ViewModels/Channel.cs
+++ b/Aerochat/ViewModels/Channel.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Aerochat.ViewModels
 {
@@ -21,19 +19,19 @@ namespace Aerochat.ViewModels
         private bool _canAttachFiles;
         private GuildViewModel? _guild;
 
-        public required string Name
+        public string Name
         {
             get => _name;
             set => SetProperty(ref _name, value);
         }
 
-        public required string Topic
+        public string Topic
         {
             get => _topic;
             set => SetProperty(ref _topic, value);
         }
 
-        public required ulong Id
+        public ulong Id
         {
             get => _id;
             set => SetProperty(ref _id, value);
@@ -75,7 +73,7 @@ namespace Aerochat.ViewModels
             return new ChannelViewModel
             {
                 Name = channel is DiscordDmChannel ? channel.Name ?? string.Join(", ", ((DiscordDmChannel)channel).Recipients.Select(x => x.DisplayName)) : channel.Name,
-                Topic = channel.Topic ?? "",
+                Topic = channel.Topic ?? string.Empty,
                 Id = channel.Id,
                 CanTalk = channel is not DiscordDmChannel dmChannel ? ((channel.PermissionsFor(channel.Guild.CurrentMember) & Permissions.SendMessages) == Permissions.SendMessages) : !dmChannel.Recipients.Select(x => x.Id).ToList().Contains(643945264868098049),
                 CanManageMessages = channel is not DiscordDmChannel ? ((channel.PermissionsFor(channel.Guild.CurrentMember) & Permissions.ManageMessages) == Permissions.ManageMessages) : false,

--- a/Aerochat/ViewModels/Chat.cs
+++ b/Aerochat/ViewModels/Chat.cs
@@ -211,7 +211,7 @@ namespace Aerochat.ViewModels
 
         public ThemeService Theme { get; } = ThemeService.Instance;
 
-        public ObservableCollection<HomeListViewCategory> Categories { get; } = [];
+        public ObservableCollection<HomeListViewCategory> Categories { get; } = new();
 
         private bool _loading = false;
 

--- a/Aerochat/ViewModels/HomeListModels.cs
+++ b/Aerochat/ViewModels/HomeListModels.cs
@@ -1,29 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.ObjectModel;
 
 namespace Aerochat.ViewModels
 {
     public class HomeListItem : ViewModelBase
     {
         private string _name;
-        public required string Name
+
+        public string Name
         {
             get => _name;
             set => SetProperty(ref _name, value);
         }
-        public class HomeListCategory : ViewModelBase
+    }
+
+    public class HomeListCategory : ViewModelBase
+    {
+        private string _name;
+
+        public string Name
         {
-            private string _name;
-            public required string Name
-            {
-                get => _name;
-                set => SetProperty(ref _name, value);
-            }
-            public ObservableCollection<HomeListItem> Items { get; } = new();
+            get => _name;
+            set => SetProperty(ref _name, value);
         }
+
+        public ObservableCollection<HomeListItem> Items { get; } = new();
     }
 }

--- a/Aerochat/ViewModels/NonNativeItem.cs
+++ b/Aerochat/ViewModels/NonNativeItem.cs
@@ -10,14 +10,14 @@ namespace Aerochat.ViewModels
     public class NonNativeItem : ViewModelBase
     {
         private string _name;
-        public required string Name
+        public string Name
         {
             get => _name;
             set => SetProperty(ref _name, value);
         }
 
         private string _key;
-        public required string Key
+        public string Key
         {
             get => _key;
             set => SetProperty(ref _key, value);

--- a/Aerochat/ViewModels/Presence.cs
+++ b/Aerochat/ViewModels/Presence.cs
@@ -18,7 +18,7 @@ namespace Aerochat.ViewModels
         private string _type = "";
         private string _customStatus = null;
 
-        public required string Type
+        public string Type
         {
             get => _type;
             set => SetProperty(ref _type, value);
@@ -30,7 +30,7 @@ namespace Aerochat.ViewModels
             set => SetProperty(ref _status, value);
         }
 
-        public required string Presence
+        public string Presence
         {
             get => _presenceString;
             set => SetProperty(ref _presenceString, value);

--- a/Aerochat/ViewModels/User.cs
+++ b/Aerochat/ViewModels/User.cs
@@ -21,22 +21,22 @@ namespace Aerochat.ViewModels
         private string? _color = "#525252";
         private string? _image;
 
-        public required string Name
+        public string Name
         {
             get => _name;
             set => SetProperty(ref _name, value);
         }
-        public required string Avatar
+        public string Avatar
         {
             get => _avatar;
             set => SetProperty(ref _avatar, value);
         }
-        public required ulong Id
+        public ulong Id
         {
             get => _id;
             set => SetProperty(ref _id, value);
         }
-        public required string Username
+        public string Username
         {
             get => _username;
             set => SetProperty(ref _username, value);

--- a/Aerochat/Windows/About.xaml.cs
+++ b/Aerochat/Windows/About.xaml.cs
@@ -58,7 +58,7 @@ namespace Aerochat.Windows
             using StreamReader reader = new(stream);
             string result = reader.ReadToEnd();
             XDocument doc = XDocument.Parse(result);
-            foreach (XElement adXml in doc.Root?.Elements() ?? [])
+            foreach (XElement adXml in doc.Root?.Elements() ?? Enumerable.Empty<XElement>())
             {
                 ads.Add(adXml);
             }

--- a/Aerochat/Windows/Chat.xaml.cs
+++ b/Aerochat/Windows/Chat.xaml.cs
@@ -52,15 +52,22 @@ using Timer = System.Timers.Timer;
 
 namespace Aerochat.Windows
 {
-    public class ToolbarItem(string text, ToolbarItemAction action, bool isEyecandy = false)
+    public class ToolbarItem
     {
-        public string Text { get; set; } = text;
+        public string Text { get; set; }
 
-        public bool IsEyecandy { get; set; } = isEyecandy;
+        public bool IsEyecandy { get; set; }
 
         public delegate void ToolbarItemAction(FrameworkElement itemElement);
 
-        public ToolbarItemAction Action { get; set; } = action;
+        public ToolbarItemAction Action { get; set; }
+
+        public ToolbarItem(string text, ToolbarItemAction action, bool isEyecandy = false)
+        {
+            Text = text;
+            Action = action;
+            IsEyecandy = isEyecandy;
+        }
     }
 
     public partial class Chat : Window
@@ -894,7 +901,7 @@ namespace Aerochat.Windows
             if (Clipboard.ContainsImage())
             {
                 BitmapSource image = Clipboard.GetImage();
-                InsertAttachmentsFromAnyThreadFromBitmapSourceArray([image]);
+                InsertAttachmentsFromAnyThreadFromBitmapSourceArray(new BitmapSource[] { image });
             }
         }
 

--- a/Aerochat/Windows/Home.xaml.cs
+++ b/Aerochat/Windows/Home.xaml.cs
@@ -207,7 +207,7 @@ namespace Aerochat.Windows
                 using StreamReader reader = new(stream);
                 string result = reader.ReadToEnd();
                 XDocument doc = XDocument.Parse(result);
-                foreach (XElement adXml in doc.Root?.Elements() ?? [])
+                foreach (XElement adXml in doc.Root?.Elements() ?? Enumerable.Empty<XElement>())
                 {
                     AdViewModel ad = AdViewModel.FromAd(adXml);
                     _ads.Add(ad);

--- a/Aerochat/Windows/NonNativeTooltip.xaml.cs
+++ b/Aerochat/Windows/NonNativeTooltip.xaml.cs
@@ -17,9 +17,14 @@ using Timer = System.Timers.Timer;
 
 namespace Aerochat.Windows
 {
-    public class ItemClickedEventArgs(NonNativeItem item) : EventArgs
+    public class ItemClickedEventArgs : EventArgs
     {
-        public NonNativeItem Item { get; set; } = item;
+        public NonNativeItem Item { get; set; }
+
+        public ItemClickedEventArgs(NonNativeItem item)
+        {
+            Item = item;
+        }
     }
     public partial class NonNativeTooltip : Window
     {

--- a/Aerotest/Aerotest.csproj
+++ b/Aerotest/Aerotest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows7.0</TargetFramework>
+		<TargetFramework>net6.0-windows7.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
@@ -13,7 +13,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
 		<PackageReference Include="NUnit" Version="3.14.0" />
 		<PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/Aerovoice/Aerovoice.csproj
+++ b/Aerovoice/Aerovoice.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Platforms>AnyCPU;x64</Platforms>

--- a/Aerovoice/Clients/VoiceSocket.cs
+++ b/Aerovoice/Clients/VoiceSocket.cs
@@ -23,7 +23,6 @@ using Aerovoice.Logging;
 using Aerovoice.Recorders;
 using Aerovoice.Encoders;
 using Aerovoice.Timestamp;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Aerovoice.Clients
 {

--- a/Aerovoice/Crypts/AeadAes256GcmRtpSize.cs
+++ b/Aerovoice/Crypts/AeadAes256GcmRtpSize.cs
@@ -37,7 +37,7 @@ namespace Aerovoice.Crypts
         }
         public override byte[] Encrypt(byte[] data, byte[] key)
         {
-            if (key is null) return [];
+            if (key is null) return Array.Empty<byte>();
             var header = new byte[12];
             Array.Copy(data, header, 12);
             var opusSpan = data.Skip(12).ToArray();

--- a/Aerovoice/Decoders/OpusDotNetDecoder.cs
+++ b/Aerovoice/Decoders/OpusDotNetDecoder.cs
@@ -24,7 +24,7 @@ namespace Aerovoice.Decoders
             {
                 FEC = true,
             });
-            byte[] decoded = [];
+            byte[] decoded = Array.Empty<byte>();
             if (lastIncrement + 1 != increment)
             {
                 decoded = decoder.Decode(null, -1, out decodedLength);


### PR DESCRIPTION
Hi! I tried compiling this project with .NET 6 and (expectedly) failed. .NET 8 makes it harder than it should be to develop this on the actual target it's intended for, which is Windows 7, since I intend to dogfood this. .NET 6 is the last version that supports Windows 7 officially, same with Visual Studio 2022 17.6, so it is a logical choice. It didn't take much to get it going, so that's what this PR is. It builds and I don't see any lack of functionality. 