### PR TITLE
Make the "Last received message" text respect the time configuration setting

### DIFF
--- a/Aerochat/ViewModels/Message.cs
+++ b/Aerochat/ViewModels/Message.cs
@@ -108,6 +108,7 @@ namespace Aerochat.ViewModels
         }
 
         private string? _timestampString = null;
+        private string? _lastMessageReceivedString = null;
 
         public string TimestampString
         {
@@ -121,10 +122,29 @@ namespace Aerochat.ViewModels
             set => SetProperty(ref _timestampString, GetTimestampString());
         }
 
+        public string LastMessageReceivedString
+        {
+            get
+            {
+                if (_lastMessageReceivedString == null)
+                    _lastMessageReceivedString = GetLastMessageReceivedString();
+                return _lastMessageReceivedString;
+            }
+
+            set => SetProperty(ref _lastMessageReceivedString, GetLastMessageReceivedString());
+        }
+
         private string GetTimestampString()
         {
             var format = SettingsManager.Instance.SelectedTimeFormat == TimeFormat.TwentyFourHour ? "HH:mm" : "h:mm tt";
             return Timestamp.ToString(format, CultureInfo.InvariantCulture);  // Ensure InvariantCulture to control formatting: Otherwise we will lose the AM/PM at the end!
+        }
+
+        private string GetLastMessageReceivedString()
+        {
+            var format = SettingsManager.Instance.SelectedTimeFormat == TimeFormat.TwentyFourHour ? "HH:mm" : "h:mm tt";
+            var time = Timestamp.ToString(format, CultureInfo.InvariantCulture);
+            return $"Last message received at {time} on {Timestamp:dd/MM/yyyy}.";
         }
 
         private DateTime _timestamp;

--- a/Aerochat/Windows/Chat.xaml
+++ b/Aerochat/Windows/Chat.xaml
@@ -1300,14 +1300,7 @@
                                                     <Setter Property="Text" Value="{Binding TypingString, Mode=OneWay}" />
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding TypingString, Mode=OneWay}" Value="">
-                                                            <Setter Property="Text">
-                                                                <Setter.Value>
-                                                                    <MultiBinding StringFormat="{}Last message received at {0:HH:mm} on {1:dd/MM/yyyy}.">
-                                                                        <Binding Path="LastReceivedMessage.Timestamp" />
-                                                                        <Binding Path="LastReceivedMessage.Timestamp" />
-                                                                    </MultiBinding>
-                                                                </Setter.Value>
-                                                            </Setter>
+                                                            <Setter Property="Text" Value="{Binding LastReceivedMessage.LastMessageReceivedString}"/>
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>

--- a/Aerochat/Windows/Chat.xaml.cs
+++ b/Aerochat/Windows/Chat.xaml.cs
@@ -950,6 +950,13 @@ namespace Aerochat.Windows
                         message.RaisePropertyChanged(nameof(message.TimestampString));
                     }
 
+                    if (ViewModel.LastReceivedMessage is not null)
+                    {
+                        var lastMessage = ViewModel.LastReceivedMessage;
+                        lastMessage.LastMessageReceivedString = "(Ignored)"; // Setter creates the value
+                        lastMessage.RaisePropertyChanged(nameof(lastMessage.LastMessageReceivedString));
+                    }
+
                     RefreshAerochatVersionLinkVisibility();
                 });
             }
@@ -1068,6 +1075,13 @@ namespace Aerochat.Windows
 
                         item.HiddenInfo = previous.Author?.Id == item.Author?.Id && !previous.Special;
 
+                    }
+
+                    // Reset the "Last message received ..." string, as the 12/24 hour
+                    // clock setting may have changed
+                    if (ViewModel.LastReceivedMessage is not null)
+                    {
+                        ViewModel.LastReceivedMessage.LastMessageReceivedString = "(Ignored)";
                     }
                 }
             });


### PR DESCRIPTION
Fixes #162.

I put the computed LastMessageReceivedString in MessageViewModel so it's nearby TimestampString and its clock logic, but I could also understand a want to have it in the Chat window.

Let me know if there are any problems.