### PR TITLE
Remove check preventing ThemeService from being initialized.

### DIFF
--- a/Aerochat/App.xaml.cs
+++ b/Aerochat/App.xaml.cs
@@ -432,25 +432,20 @@ namespace Aerochat
                 SettingsManager.Instance.HasUserLoggedInBefore = true;
                 SettingsManager.Save();
             }
-            DiscordColor? colour = Discord.Client.CurrentUser.BannerColor;
-            if (colour != null)
+            SceneViewModel scene = SceneViewModel.FromUser(Discord.Client.CurrentUser);
+            // clone the scene into ThemeService.Instance.Scene, so that its not by reference
+            if (scene != null)
             {
-                string hex = $"#{colour.Value.R:X2}{colour.Value.G:X2}{colour.Value.B:X2}";
-                SceneViewModel scene = SceneViewModel.FromUser(Discord.Client.CurrentUser);
-                // clone the scene into ThemeService.Instance.Scene, so that its not by reference
-                if (scene != null)
+                ThemeService.Instance.Scene = new SceneViewModel
                 {
-                    ThemeService.Instance.Scene = new SceneViewModel
-                    {
-                        Id = scene.Id,
-                        File = scene.File,
-                        DisplayName = scene.DisplayName,
-                        Color = scene.Color,
-                        Default = scene.Default,
-                        TextColor = scene.TextColor,
-                        ShadowColor = scene.ShadowColor,
-                    };
-                }
+                    Id = scene.Id,
+                    File = scene.File,
+                    DisplayName = scene.DisplayName,
+                    Color = scene.Color,
+                    Default = scene.Default,
+                    TextColor = scene.TextColor,
+                    ShadowColor = scene.ShadowColor,
+                };
             }
             Dispatcher.Invoke(() =>
             {


### PR DESCRIPTION
Fixes #165.

When Discord.Client.CurrentUser.BannerColor is null, ThemeService is not initialized, and clicking on the scene will cause the client to crash.

Since the variable BannerColor is assigned to is unused, and since this code hasn't been touched in two years, I just removed the check. This fixes the crash on my end.