### PR TITLE
fix: LastMessageReceivedString now respects local date region configuration

### DIFF
--- a/Aerochat/ViewModels/Message.cs
+++ b/Aerochat/ViewModels/Message.cs
@@ -144,7 +144,7 @@ namespace Aerochat.ViewModels
         {
             var format = SettingsManager.Instance.SelectedTimeFormat == TimeFormat.TwentyFourHour ? "HH:mm" : "h:mm tt";
             var time = Timestamp.ToString(format, CultureInfo.InvariantCulture);
-            return $"Last message received at {time} on {Timestamp:dd/MM/yyyy}.";
+            return $"Last message received at {time} on {Timestamp.ToShortDateString()}.";
         }
 
         private DateTime _timestamp;


### PR DESCRIPTION
The rest of the LastMessageReceivedString from PR #166 seemed good to me, but the date format was hardcoded rather than using `.ToShortDateString` which is culture insensitive and uses the local machine's date formatting.